### PR TITLE
Add Pyodide export helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ pytest
 
 The tests are located in `tests/test_capital_engine.py` and exercise the
 `capital_engine` package defined in `capital_engine/__init__.py`.
+
+## Preparing for Pyodide
+
+Use `scripts/export_pyodide.py` to copy the canonical `capital_engine` source
+into `src/lib/model.py` for use with Pyodide:
+
+```bash
+python scripts/export_pyodide.py
+```
+
+This script imports the package and writes its source to the destination so
+there is only one authoritative implementation of the model.

--- a/scripts/export_pyodide.py
+++ b/scripts/export_pyodide.py
@@ -1,0 +1,15 @@
+import importlib
+import inspect
+from pathlib import Path
+
+
+def main():
+    module = importlib.import_module('capital_engine')
+    src = inspect.getsource(module)
+    dest = Path('src/lib/model.py')
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(src)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to export the canonical `capital_engine` module for Pyodide
- document the script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3e801a3c8326998df4c1aa9402d8