### PR TITLE
feat: expose pyodide model API

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,19 @@
+import type { PyodideInterface } from 'pyodide';
+import { loadPyodide } from 'pyodide';
+
+let pyodidePromise: Promise<PyodideInterface> | null = null;
+
+export async function runModel(): Promise<any> {
+  if (!pyodidePromise) {
+    pyodidePromise = loadPyodide();
+  }
+  const pyodide = await pyodidePromise;
+  await pyodide.loadPackage(['pandas']);
+  const modelUrl = new URL('./model.py', import.meta.url);
+  const code = await (await fetch(modelUrl)).text();
+  await pyodide.runPythonAsync(code);
+  const run = pyodide.globals.get('run');
+  const result = run();
+  run.destroy();
+  return result.toJs();
+}

--- a/src/lib/components/ScenarioGrid.svelte
+++ b/src/lib/components/ScenarioGrid.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { runModel } from '$lib/api';
-  let data = [], columns = [];
+  let data: Record<string, any>[] = [];
+  let columns: { accessorKey: string }[] = [];
   onMount(async () => {
-    const json = await runModel();
+    const json: { data: Record<string, any>[]; schema: { fields: { name: string }[] } } = await runModel();
     data = json.data;
-    columns = json.schema.fields.map(f => ({ accessorKey: f.name }));
+    columns = json.schema.fields.map((f: { name: string }) => ({ accessorKey: f.name }));
   });
 </script>
 

--- a/src/lib/model.py
+++ b/src/lib/model.py
@@ -1,0 +1,89 @@
+import pandas as pd
+
+
+def recalc(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    start_cols = [
+        "shares_start",
+        "cet1_start",
+        "acl_start",
+        "at1_start",
+        "sub_principal_start",
+        "sub_years_start",
+    ]
+    df[start_cols] = df[start_cols].ffill()
+
+    for i, idx in enumerate(df.index):
+        row = df.loc[idx]
+        shares_end = (
+            row["shares_start"]
+            + row["equity_dollars"] / row["equity_price"]
+            - row["buyback_dollars"] / row["buyback_price"]
+        )
+        df.at[idx, "shares_end"] = shares_end
+
+        net_income = (
+            row["pre_tax_income"] - row["provision"] - row["net_charge_offs"]
+        ) * (1 - row["tax_rate"])
+        dividends = row["div_per_share"] * shares_end
+        cet1_end = (
+            row["cet1_start"]
+            + net_income
+            - dividends
+            - row["buyback_dollars"]
+            + row["equity_dollars"]
+        )
+        df.at[idx, "cet1_end"] = cet1_end
+
+        at1_end = row["at1_start"] + row["at1_issue"] - row["at1_redm"]
+        df.at[idx, "at1_end"] = at1_end
+
+        recognised_sub = row["sub_principal_start"]
+        df.at[idx, "recognised_sub"] = recognised_sub
+
+        tier2_end = recognised_sub + row["sub_issue"] - row["sub_redemption"]
+        df.at[idx, "tier2_end"] = tier2_end
+
+        df.at[idx, "cet1_ratio"] = cet1_end / row["rwa"]
+        df.at[idx, "total_ratio"] = (cet1_end + at1_end + tier2_end) / row["rwa"]
+
+        if i + 1 < len(df.index):
+            next_idx = df.index[i + 1]
+            df.at[next_idx, "shares_start"] = shares_end
+            df.at[next_idx, "cet1_start"] = cet1_end
+            df.at[next_idx, "at1_start"] = at1_end
+            df.at[next_idx, "acl_start"] = row["acl_start"]
+            df.at[next_idx, "sub_principal_start"] = row["sub_principal_start"]
+            df.at[next_idx, "sub_years_start"] = row["sub_years_start"]
+
+    return df
+
+
+def default_df() -> pd.DataFrame:
+    d = {
+        'period':['24Q4','25Q1','25Q2'],
+        'pre_tax_income':[2.029,2.067,2.226],
+        'provision':[0.156,0.219,0.254],
+        'net_charge_offs':[0.120,0.140,0.150],
+        'tax_rate':[0.18,0.18,0.18],
+        'rwa':[416,420,425],
+        'div_per_share':[1.60,1.60,1.60],
+        'shares_start':[398,None,None],
+        'buyback_dollars':[0.20,0.20,0.30],
+        'buyback_price':[140,140,140],
+        'equity_dollars':[0,0,0],
+        'equity_price':[140,140,140],
+        'at1_issue':[0,0,0],'at1_redm':[0,0,0],
+        'cet1_start':[44.0,None,None],'at1_start':[5.1,None,None],
+        'acl_start':[6.0,None,None],
+        'sub_principal_start':[7.0,None,None],'sub_years_start':[6.0,None,None],
+        'sub_issue':[0,0,0],'sub_issue_maturity':[10,10,10],'sub_redemption':[0,0,0]
+    }
+    return pd.DataFrame(d).set_index('period')
+
+
+def run():
+    df = recalc(default_df()).reset_index()
+    schema = {"fields": [{"name": name} for name in df.columns]}
+    data = df.to_dict(orient="records")
+    return {"schema": schema, "data": data}

--- a/src/lib/pyodide.d.ts
+++ b/src/lib/pyodide.d.ts
@@ -1,0 +1,4 @@
+declare module 'pyodide' {
+  export type PyodideInterface = any;
+  export function loadPyodide(options?: any): Promise<PyodideInterface>;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,7 +8,7 @@ let { children } = $props();
 <svelte:head>
         <link rel="icon" href={favicon} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
 </svelte:head>
 


### PR DESCRIPTION
## Summary
- load Python model via Pyodide and return schema/data JSON
- add Python model with default dataset and recalc logic
- type ScenarioGrid and adjust layout cross-origin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e567a0a208326825644be019cf5a3