### PR TITLE
Package capital_engine and simplify test imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ structured.
 
 ## Installation
 
-Create a virtual environment (optional) and install the dependencies:
+Create a virtual environment (optional) and install the package in editable
+mode for development:
 
 ```bash
-pip install -r requirements.txt
+pip install -e .
 ```
+
+This installs ``capital_engine`` along with its Python dependencies so that
+changes to the source are immediately reflected.
 
 ## Running the tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "capital_engine"
+version = "0.1.0"
+description = "Capital forecast engine prototype"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+  "pandas",
+  "numpy",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+

--- a/tests/test_capital_engine.py
+++ b/tests/test_capital_engine.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
 import pandas as pd
 import numpy as np
 from capital_engine import recalc, apply_overrides, compare


### PR DESCRIPTION
## Summary
- package `capital_engine` as an installable module via `pyproject.toml`
- update tests to import the package without `sys.path` tweaks
- document editable installation in README

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5835f9c883268c6ba27b0ddacdd9