### PR TITLE
Run export_pyodide during dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ The tests are located in `tests/test_capital_engine.py` and exercise the
 
 The build process automatically runs `scripts/export_pyodide.py` to copy the
 canonical `capital_engine` source into `src/lib/model.py` for use with
-Pyodide. The generated file is ignored by Git and kept in sync whenever
-`npm run build` is executed. If you need to refresh it manually, run:
+Pyodide. This generated file must exist for the frontend to function; if it is
+missing the client will fail to fetch the model. The file is ignored by Git and
+kept in sync whenever `npm run build` or `npm run dev` is executed. If you need
+to refresh it manually, run:
 
 ```bash
 python scripts/export_pyodide.py

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+                "dev": "python -m scripts.export_pyodide && vite dev",
                 "prebuild": "python -m scripts.export_pyodide",
                 "build": "vite build",
 		"preview": "vite preview",


### PR DESCRIPTION
## Summary
- Ensure `npm run dev` exports the Python model before starting Vite
- Clarify that the generated `src/lib/model.py` file is required by the frontend

## Testing
- `pytest`
- `npm run check`
- `npm run dev` *(verified generation of `src/lib/model.py` and availability of app resources)*

------
https://chatgpt.com/codex/tasks/task_e_688e5ecc7670832688e85afd894b73e6