### PR TITLE
Add typed period labels and tidy input page

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,7 +25,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '24Q4' as any
+    period: '24Q4'
   },
   {
     sharesStart: 398.0,
@@ -49,7 +49,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '25Q1' as any
+    period: '25Q1'
   },
   {
     sharesStart: 398.0,
@@ -73,7 +73,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '25Q2' as any
+    period: '25Q2'
   }
 ];
 
@@ -81,7 +81,7 @@ export const baseScenario: Table = [
  * Execute the capital engine on the base scenario and return data with a schema.
  */
 export async function runModel(): Promise<{ data: any[]; schema: { fields: { name: string }[] } }> {
-  const result = recalc(baseScenario as any);
+  const result = recalc(baseScenario);
   const fields = Object.keys(result[0] ?? {}).map((name) => ({ name }));
   return { data: result as any[], schema: { fields } };
 }

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -13,6 +13,8 @@ export const SUB_FULL_CREDIT_YEARS = 5.0;   // sub‑debt full credit ≥5 yrs
 
 ////////////// ─── type definitions ─────────────────
 export interface PeriodInput {
+  // descriptive period label (e.g. '24Q4')
+  period: string;
   // starting balances (first row supplied; later rows filled by engine)
   sharesStart: number;
   cet1Start: number;

--- a/src/routes/input/+page.svelte
+++ b/src/routes/input/+page.svelte
@@ -1,4 +1,3 @@
-https://github.com/jrohan-16/jrohan-16.github.io/new/main/src/routes/input
 <script lang="ts">
   import { onMount } from 'svelte';
   import { baseScenario } from '$lib/api';
@@ -28,7 +27,7 @@ https://github.com/jrohan-16/jrohan-16.github.io/new/main/src/routes/input
   }
 
   function updateResults() {
-    const result = recalc(scenario as any);
+    const result = recalc(scenario);
     const { rows, cols } = pivotData(result as any[]);
     data = rows;
     columns = cols;


### PR DESCRIPTION
## Summary
- Add `period` field to engine input rows and remove `any` casts in API
- Trim stray URL and rely on typed scenario in the input page

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f8b3b80808326b54f1dafb07e6d52