### PR TITLE
Improve table value formatting

### DIFF
--- a/src/lib/components/DataTable.svelte
+++ b/src/lib/components/DataTable.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
   export let data: Record<string, any>[] = [];
   export let columns: { accessorKey: string }[] = [];
+
+  function formatValue(value: any, key: string) {
+    if (typeof value === 'number') {
+      const lower = key.toLowerCase();
+      if (lower.includes('ratio') || lower.includes('rate')) {
+        return `${(value * 100).toFixed(2)}%`;
+      }
+      return value.toFixed(1);
+    }
+    return value;
+  }
 </script>
 
 <table class="min-w-full text-sm border border-gray-300">
@@ -15,7 +26,11 @@
     {#each data as row, i}
       <tr class={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
         {#each columns as col}
-          <td class="px-2 py-1 border-b">{row[col.accessorKey]}</td>
+          {#if col.accessorKey === 'metric'}
+            <td class="px-2 py-1 border-b">{row.metric}</td>
+          {:else}
+            <td class="px-2 py-1 border-b">{formatValue(row[col.accessorKey], row.metric)}</td>
+          {/if}
         {/each}
       </tr>
     {/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,5 +30,6 @@
 
 <div class="p-6 bg-white">
   <h1 class="text-xl font-bold mb-4">Dashboard</h1>
+  <p class="text-sm text-gray-600 mb-4">All amounts in $ billions.</p>
   <DataTable {data} {columns} />
 </div>


### PR DESCRIPTION
## Summary
- format table values: one decimal for numbers, two decimals plus % for ratios
- note units are in $ billions on dashboard

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6890e90efc388326be3a368475fe691f