### PR TITLE
style: reformat quarter labels

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,7 +25,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '24Q4'
+    period: '4Q24'
   },
   {
     sharesStart: 398.0,
@@ -49,7 +49,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '25Q1'
+    period: '1Q25'
   },
   {
     sharesStart: 398.0,
@@ -73,7 +73,7 @@ export const baseScenario: Table = [
     subRedemption: 0,
     at1Issue: 0,
     at1Redm: 0,
-    period: '25Q2'
+    period: '2Q25'
   }
 ];
 

--- a/src/lib/engine.ts
+++ b/src/lib/engine.ts
@@ -13,7 +13,7 @@ export const SUB_FULL_CREDIT_YEARS = 5.0;   // sub‑debt full credit ≥5 yrs
 
 ////////////// ─── type definitions ─────────────────
 export interface PeriodInput {
-  // descriptive period label (e.g. '24Q4')
+  // descriptive period label (e.g. '1Q25')
   period: string;
   // starting balances (first row supplied; later rows filled by engine)
   sharesStart: number;


### PR DESCRIPTION
## Summary
- use quarter-first period labels in sample data and engine comment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6894033f99b88326a592d216a6791c17