### PR TITLE
Delay refresh until data available

### DIFF
--- a/scripts/refresh-fry9c.cjs
+++ b/scripts/refresh-fry9c.cjs
@@ -82,19 +82,33 @@ const BASE_URL =
 function getQuarterEndDates(numQuarters = 4) {
   const dates = [];
   const today = new Date();
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const SWITCH_DELAY_DAYS = 44;
   let year = today.getUTCFullYear();
   let quarter = Math.floor((today.getUTCMonth()) / 3) + 1;
-  // Use the last completed quarter
-  if (today.getUTCMonth() % 3 !== 2 || today.getUTCDate() < 15) {
+
+  // Determine the most recent quarter end
+  let quarterEnd = new Date(Date.UTC(year, quarter * 3, 0));
+  if (today < quarterEnd) {
     quarter--;
     if (quarter < 1) {
       quarter = 4;
       year -= 1;
     }
+    quarterEnd = new Date(Date.UTC(year, quarter * 3, 0));
   }
+
+  // Only switch to the new quarter once 44 days have passed
+  if (today - quarterEnd < SWITCH_DELAY_DAYS * MS_PER_DAY) {
+    quarter--;
+    if (quarter < 1) {
+      quarter = 4;
+      year--;
+    }
+  }
+
   for (let i = 0; i < numQuarters; i++) {
-    const month = quarter * 3; // 3, 6, 9, 12
-    const endDate = new Date(Date.UTC(year, month, 0)); // last day of the month
+    const endDate = new Date(Date.UTC(year, quarter * 3, 0)); // last day of the month
     const y = endDate.getUTCFullYear();
     const m = String(endDate.getUTCMonth() + 1).padStart(2, '0');
     const d = String(endDate.getUTCDate()).padStart(2, '0');


### PR DESCRIPTION
## Summary
- wait 44 days after quarter end before switching dates in FR Y-9C refresh script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6894bc6252d4832696222f657b509e50