### PR TITLE
Revamp layout and tables for responsive design

### DIFF
--- a/src/components/DataTable.svelte
+++ b/src/components/DataTable.svelte
@@ -6,23 +6,25 @@
   export let values: number[][];
 </script>
 
-<table class="table-standard">
-  <thead>
-    <tr>
-      <th class="table-label">Metric</th>
-      {#each columns as c}
-        <th class="table-number">{c}</th>
-      {/each}
-    </tr>
-  </thead>
-  <tbody>
-    {#each rows as r, i}
+<div class="table-container">
+  <table class="table-standard">
+    <thead>
       <tr>
-        <td class="table-label">{r}</td>
-        {#each values[i] as v}
-          <td class="table-number">{formatMillions(v)}</td>
+        <th class="table-label">Metric</th>
+        {#each columns as c}
+          <th class="table-number">{c}</th>
         {/each}
       </tr>
-    {/each}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {#each rows as r, i}
+        <tr>
+          <td class="table-label">{r}</td>
+          {#each values[i] as v}
+            <td class="table-number">{formatMillions(v)}</td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/components/DeltaTable.svelte
+++ b/src/components/DeltaTable.svelte
@@ -7,24 +7,26 @@
   export let values: number[][];
 </script>
 
-<h3 class="font-semibold mb-2">{title}</h3>
-<table class="table-standard">
-  <thead>
-    <tr>
-      <th class="table-label">Metric</th>
-      {#each columns as c}
-        <th class="table-number">{c}</th>
-      {/each}
-    </tr>
-  </thead>
-  <tbody>
-    {#each rows as r, i}
+<h3 class="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">{title}</h3>
+<div class="table-container">
+  <table class="table-standard">
+    <thead>
       <tr>
-        <td class="table-label">{r}</td>
-        {#each values[i] as v}
-          <td class="table-number">{formatDeltaMillions(v)}</td>
+        <th class="table-label">Metric</th>
+        {#each columns as c}
+          <th class="table-number">{c}</th>
         {/each}
       </tr>
-    {/each}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {#each rows as r, i}
+        <tr>
+          <td class="table-label">{r}</td>
+          {#each values[i] as v}
+            <td class="table-number">{formatDeltaMillions(v)}</td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/components/EditableGrid.svelte
+++ b/src/components/EditableGrid.svelte
@@ -31,33 +31,35 @@
   }
 </script>
 
-<table class="table-standard">
-  <thead>
-    <tr>
-      <th class="table-label">Quarter</th>
-      {#each fields as [k,label]}
-        <th class="table-number">{label}</th>
-      {/each}
-    </tr>
-  </thead>
-  <tbody>
-    {#each Object.keys(bank.quarters).sort() as q}
+<div class="table-container">
+  <table class="table-standard">
+    <thead>
       <tr>
-        <td class="table-label">{q}</td>
-        {#each fields as [k]}
-          <td>
-            <input
-              class="table-input table-number"
-              type="number"
-              step="0.01"
-              inputmode="decimal"
-              placeholder="-123.45"
-              value={getValue(q, k)}
-              on:input={(event) => handleInput(q, k, event)}
-            />
-          </td>
+        <th class="table-label">Quarter</th>
+        {#each fields as [k, label]}
+          <th class="table-number">{label}</th>
         {/each}
       </tr>
-    {/each}
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      {#each Object.keys(bank.quarters).sort() as q}
+        <tr>
+          <td class="table-label">{q}</td>
+          {#each fields as [k]}
+            <td>
+              <input
+                class="table-input table-number"
+                type="number"
+                step="0.01"
+                inputmode="decimal"
+                placeholder="-123.45"
+                value={getValue(q, k)}
+                on:input={(event) => handleInput(q, k, event)}
+              />
+            </td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,31 +8,46 @@
     { href: '/compare', label: 'Compare' },
     { href: '/export', label: 'Export' }
   ] as const;
+
+  let mobileNavOpen = false;
+  let lastPathname: string | null = null;
+
+  function toggleMobileNav() {
+    mobileNavOpen = !mobileNavOpen;
+  }
+
+  $: {
+    const current = $page.url.pathname;
+    if (current !== lastPathname) {
+      lastPathname = current;
+      mobileNavOpen = false;
+    }
+  }
 </script>
 
 <div class="min-h-screen bg-slate-100 text-slate-900">
-  <header class="bg-slate-900 text-slate-100 shadow-sm">
-    <div
-      class="mx-auto flex w-full max-w-6xl flex-col gap-5 px-4 py-6 sm:flex-row sm:items-center sm:justify-between"
-    >
-      <div class="flex flex-wrap items-center gap-3 text-left">
+  <header
+    class="sticky top-0 z-40 border-b border-slate-800/60 bg-slate-950/85 text-slate-100 backdrop-blur supports-[backdrop-filter]:bg-slate-950/70"
+  >
+    <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:py-5">
+      <a href="/" class="flex items-center gap-3 text-left">
         <div
-          class="flex h-12 w-12 items-center justify-center rounded-full bg-slate-800 text-lg font-semibold tracking-tight"
+          class="flex h-12 w-12 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-lg font-semibold tracking-tight shadow-lg shadow-slate-900/40"
         >
           CF
         </div>
         <div class="min-w-0">
           <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Capital Forecast</p>
-          <p class="text-lg font-semibold leading-tight">Rate Card Dashboard</p>
+          <p class="text-lg font-semibold leading-tight text-white sm:text-xl">Rate Card Dashboard</p>
         </div>
-      </div>
-      <div class="flex w-full flex-col gap-4 sm:w-auto sm:flex-row sm:items-center sm:gap-6">
-        <nav class="flex flex-wrap items-center gap-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em]">
+      </a>
+      <div class="flex items-center gap-3 sm:gap-6">
+        <nav class="hidden items-center gap-1 text-[0.75rem] font-semibold uppercase tracking-[0.25em] sm:flex">
           {#each navLinks as item}
             <a
               href={item.href}
               aria-current={$page.url.pathname === item.href ? 'page' : undefined}
-              class={`rounded-full px-4 py-2 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${
+              class={`rounded-full px-4 py-2 text-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${
                 $page.url.pathname === item.href
                   ? 'bg-slate-100 text-slate-900 shadow-sm'
                   : 'text-slate-200 hover:bg-slate-800/80 hover:text-white focus-visible:bg-slate-800/70 focus-visible:text-white'
@@ -42,13 +57,62 @@
             </a>
           {/each}
         </nav>
-        <div class="sm:self-stretch">
+        <div class="hidden min-w-[200px] sm:block">
+          <BankSelector />
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center justify-center rounded-full border border-slate-700/70 bg-slate-900/90 p-2 text-slate-200 transition sm:hidden"
+          on:click={toggleMobileNav}
+          aria-expanded={mobileNavOpen}
+          aria-controls="site-navigation"
+        >
+          <span class="sr-only">Toggle navigation</span>
+          <svg
+            class={`h-5 w-5 transition-transform ${mobileNavOpen ? 'scale-95' : 'scale-100'}`}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            {#if mobileNavOpen}
+              <path d="M6 6l12 12M6 18L18 6" />
+            {:else}
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            {/if}
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      id="site-navigation"
+      class={`sm:hidden ${mobileNavOpen ? 'grid-rows-[1fr] opacity-100' : 'pointer-events-none grid-rows-[0fr] opacity-0'} grid transform border-t border-slate-800/70 bg-slate-950/95 transition-all duration-200 ease-out`}
+    >
+      <div class="overflow-hidden">
+        <nav class="flex flex-col gap-1 px-4 py-4 text-sm font-medium uppercase tracking-[0.2em] text-slate-200">
+          {#each navLinks as item}
+            <a
+              href={item.href}
+              aria-current={$page.url.pathname === item.href ? 'page' : undefined}
+              class={`rounded-xl px-4 py-3 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 ${
+                $page.url.pathname === item.href
+                  ? 'bg-slate-100 text-slate-900 shadow-sm'
+                  : 'hover:bg-slate-800/80 hover:text-white focus-visible:bg-slate-800/70 focus-visible:text-white'
+              }`}
+            >
+              {item.label}
+            </a>
+          {/each}
+        </nav>
+        <div class="border-t border-slate-800/70 px-4 py-4">
           <BankSelector />
         </div>
       </div>
     </div>
   </header>
-  <main class="mx-auto w-full max-w-6xl px-4 py-6">
+  <main class="mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:pt-10">
     <slot />
   </main>
 </div>
@@ -62,8 +126,7 @@
   }
 
   :global(a) {
-    color: #1d4ed8;
-    font-weight: 600;
+    color: inherit;
     text-decoration: none;
   }
 
@@ -71,55 +134,135 @@
     text-decoration: underline;
   }
 
+  :global(.sr-only) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+    white-space: nowrap;
+  }
+
+  :global(.table-container) {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.5rem;
+  }
+
+  :global(.table-container::-webkit-scrollbar) {
+    height: 8px;
+  }
+
+  :global(.table-container::-webkit-scrollbar-thumb) {
+    background-color: rgba(15, 23, 42, 0.2);
+    border-radius: 9999px;
+  }
+
   :global(.table-standard) {
     width: 100%;
-    border-collapse: collapse;
+    min-width: 620px;
+    border-collapse: separate;
+    border-spacing: 0;
     border: 1px solid #cbd5e1;
-    border-radius: 0.75rem;
-    overflow: hidden;
+    border-radius: 0.9rem;
     background-color: #ffffff;
+    box-shadow: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+  }
+
+  :global(.table-standard thead th) {
+    background: linear-gradient(180deg, rgba(30, 41, 59, 0.95) 0%, rgba(15, 23, 42, 0.92) 100%);
+    color: #e2e8f0;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    padding: 1rem 1.25rem;
+    position: sticky;
+    top: 0;
+    z-index: 4;
+  }
+
+  :global(.table-standard thead th + th) {
+    border-left: 1px solid rgba(148, 163, 184, 0.3);
   }
 
   :global(.table-standard th),
   :global(.table-standard td) {
-    padding: 0.75rem 1rem;
-    border: 1px solid #cbd5e1;
+    border: none;
+    padding: 1rem 1.25rem;
+    font-size: 0.95rem;
+    line-height: 1.55;
     vertical-align: middle;
   }
 
-  :global(.table-standard thead th) {
-    background: linear-gradient(180deg, #e0e7ff 0%, #eef2ff 100%);
-    color: #1e293b;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    text-transform: uppercase;
-    font-size: 0.75rem;
+  :global(.table-standard tbody td) {
+    border-bottom: 1px solid #e2e8f0;
+    background-color: #ffffff;
   }
 
-  :global(.table-standard thead th:first-child) {
-    border-top-left-radius: 0.75rem;
+  :global(.table-standard tbody td + td) {
+    border-left: 1px solid #e2e8f0;
   }
 
-  :global(.table-standard thead th:last-child) {
-    border-top-right-radius: 0.75rem;
-  }
-
-  :global(.table-standard tbody tr) {
-    transition: background-color 0.15s ease, box-shadow 0.15s ease;
-  }
-
-  :global(.table-standard tbody tr:nth-child(even)) {
+  :global(.table-standard tbody tr:nth-child(even) td) {
     background-color: #f8fafc;
   }
 
+  :global(.table-standard tbody tr:hover td) {
+    background-color: #e8eef9;
+  }
+
+  :global(.table-standard tbody tr:last-child td) {
+    border-bottom: none;
+  }
+
+  :global(.table-standard th:first-child),
+  :global(.table-standard td:first-child) {
+    position: sticky;
+    left: 0;
+    z-index: 3;
+    background-color: #ffffff;
+    box-shadow: 4px 0 12px -8px rgba(15, 23, 42, 0.25);
+  }
+
+  :global(.table-standard tbody tr:nth-child(even) td:first-child) {
+    background-color: #f8fafc;
+  }
+
+  :global(.table-standard tbody tr:hover td:first-child) {
+    background-color: #e8eef9;
+  }
+
+  :global(.table-standard thead th:first-child) {
+    border-top-left-radius: 0.9rem;
+    z-index: 5;
+    background: linear-gradient(180deg, rgba(30, 41, 59, 1) 0%, rgba(15, 23, 42, 0.95) 100%);
+  }
+
+  :global(.table-standard thead th:last-child) {
+    border-top-right-radius: 0.9rem;
+  }
+
+  :global(.table-standard tbody tr) {
+    transition: background-color 0.18s ease, box-shadow 0.18s ease;
+  }
+
   :global(.table-standard tbody tr:hover) {
-    background-color: #e2e8f0;
+    box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.4);
   }
 
   :global(.table-standard .table-label) {
     text-align: left;
-    font-weight: 500;
+    font-weight: 600;
     color: #0f172a;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
   }
 
   :global(.table-standard .table-number) {
@@ -128,14 +271,15 @@
       'Liberation Mono', 'Courier New', monospace;
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.01em;
+    color: #1e293b;
   }
 
   :global(.table-input) {
     width: 100%;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.5rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 0.65rem;
     border: 1px solid #cbd5e1;
-    background-color: #f8fafc;
+    background-color: #f1f5f9;
     color: #0f172a;
     font-size: 0.95rem;
     transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
@@ -152,7 +296,7 @@
     outline: 3px solid rgba(59, 130, 246, 0.35);
     outline-offset: 1px;
     border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
     background-color: #ffffff;
   }
 
@@ -160,15 +304,43 @@
     color: #94a3b8;
   }
 
-  @media (max-width: 640px) {
-    :global(.table-standard th),
-    :global(.table-standard td) {
-      padding: 0.5rem 0.75rem;
-      font-size: 0.85rem;
+  @media (max-width: 768px) {
+    :global(.table-standard) {
+      min-width: 560px;
     }
 
     :global(.table-standard thead th) {
+      font-size: 0.75rem;
+      padding: 0.75rem 1rem;
+    }
+
+    :global(.table-standard th),
+    :global(.table-standard td) {
+      padding: 0.75rem 1rem;
+      font-size: 0.9rem;
+    }
+
+    :global(.table-standard .table-label) {
+      font-size: 0.9rem;
+    }
+
+    :global(.table-container) {
+      margin-left: -1rem;
+      margin-right: -1rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    :global(.table-standard thead th) {
       font-size: 0.7rem;
+      letter-spacing: 0.05em;
+    }
+
+    :global(.table-standard th),
+    :global(.table-standard td) {
+      padding: 0.65rem 0.85rem;
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<h1 class="text-xl font-semibold mb-3">Dashboard</h1>
+<h1 class="mb-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Dashboard</h1>
 {#if pivot}
   <DataTable columns={pivot.columns} rows={pivot.rows} values={pivot.values} />
 {:else}

--- a/src/routes/compare/+page.svelte
+++ b/src/routes/compare/+page.svelte
@@ -21,18 +21,18 @@
   });
 </script>
 
-<h1 class="text-xl font-semibold mb-3">Compare</h1>
-<div class="grid md:grid-cols-3 gap-6">
-  <div>
-    <h3 class="font-semibold mb-2">JPM</h3>
+<h1 class="mb-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Compare</h1>
+<div class="grid gap-8 lg:grid-cols-3">
+  <div class="space-y-3">
+    <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">JPM</h3>
     {#if pl}<DataTable columns={pl.columns} rows={pl.rows} values={pl.values} />{/if}
   </div>
-  <div>
-    <h3 class="font-semibold mb-2">PNC</h3>
+  <div class="space-y-3">
+    <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">PNC</h3>
     {#if pr}<DataTable columns={pr.columns} rows={pr.rows} values={pr.values} />{/if}
   </div>
-  <div>
-    <h3 class="font-semibold mb-2">Delta (JPM - PNC)</h3>
+  <div class="space-y-3">
+    <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Delta (JPM - PNC)</h3>
     {#if d}<DataTable columns={d.columns} rows={d.rows} values={d.values} />{/if}
   </div>
 </div>

--- a/src/routes/edit/+page.svelte
+++ b/src/routes/edit/+page.svelte
@@ -77,22 +77,38 @@
   }
 </script>
 
-<h1 class="text-xl font-semibold mb-3">Edit Actuals</h1>
-<p class="text-sm mb-4">Edit quarterly values (in $ millions) to see the scenario and deltas vs. actual.</p>
-<div class="flex gap-2 mb-3">
-  <button class="border rounded px-2 py-1" on:click={undo} disabled={!undoable?.canUndo()}>Undo</button>
-  <button class="border rounded px-2 py-1" on:click={redo} disabled={!undoable?.canRedo()}>Redo</button>
+<h1 class="mb-2 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Edit Actuals</h1>
+<p class="mb-6 max-w-3xl text-sm text-slate-600 sm:text-base">
+  Edit quarterly values (in $ millions) to see the refreshed scenario projections and how they differ from actuals.
+</p>
+<div class="mb-4 flex flex-wrap gap-2">
+  <button
+    class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400 disabled:shadow-none"
+    on:click={undo}
+    disabled={!undoable?.canUndo()}
+  >
+    Undo
+  </button>
+  <button
+    class="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400 disabled:shadow-none"
+    on:click={redo}
+    disabled={!undoable?.canRedo()}
+  >
+    Redo
+  </button>
 </div>
 
 {#if base && working}
-  <EditableGrid bank={working} onChange={onChange} class="mb-4" />
-  <div class="grid md:grid-cols-2 gap-6 mt-6">
-    <div>
-      <h3 class="font-semibold mb-2">Scenario</h3>
-      <DataTable columns={pWork.columns} rows={pWork.rows} values={pWork.values} />
-    </div>
-    <div>
-      <DeltaTable title="Delta vs. Actual" columns={delta.columns} rows={delta.rows} values={delta.values} />
+  <div class="space-y-8">
+    <EditableGrid bank={working} onChange={onChange} />
+    <div class="grid gap-8 md:grid-cols-2">
+      <div>
+        <h3 class="mb-3 text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Scenario</h3>
+        <DataTable columns={pWork.columns} rows={pWork.rows} values={pWork.values} />
+      </div>
+      <div>
+        <DeltaTable title="Delta vs. Actual" columns={delta.columns} rows={delta.rows} values={delta.values} />
+      </div>
     </div>
   </div>
 {:else}

--- a/src/routes/export/+page.svelte
+++ b/src/routes/export/+page.svelte
@@ -36,9 +36,18 @@
   });
 </script>
 
-<h1 class="text-xl font-semibold mb-3">Export</h1>
+<h1 class="mb-2 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Export</h1>
+<p class="mb-6 max-w-2xl text-sm text-slate-600 sm:text-base">
+  Download the latest scenario results as a CSV so you can share them or run deeper analysis offline.
+</p>
 {#if url}
-  <a class="underline" href={url} download="scenario.csv">Download CSV</a>
+  <a
+    class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+    href={url}
+    download="scenario.csv"
+  >
+    Download CSV
+  </a>
 {:else}
-  <p>Preparing…</p>
+  <p class="text-sm text-slate-500">Preparing…</p>
 {/if}


### PR DESCRIPTION
## Summary
- replace the global header with a sticky, branded navigation bar that adapts to mobile with a collapsible menu and integrated bank selector
- refresh global table styling with larger typography, column delineation, sticky row labels, and responsive scroll containers
- polish page-level typography and controls so dashboard, edit, compare, and export views follow the updated visual system

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e952a6b4c483269c6d7aa46a03b19a